### PR TITLE
Symbols fixup

### DIFF
--- a/lib/bitmask_attributes/value_proxy.rb
+++ b/lib/bitmask_attributes/value_proxy.rb
@@ -13,6 +13,7 @@ module BitmaskAttributes
     # = OVERRIDE TO SERIALIZE =
     # =========================
     
+    alias_method :orig_replace, :replace
     %w(push << delete replace reject! select!).each do |override|
       class_eval(<<-EOEVAL)
         def #{override}(*args)
@@ -39,8 +40,13 @@ module BitmaskAttributes
         end
       end
     
+      def symbolize!
+        orig_replace(map(&:to_sym))
+      end
+
       def updated!
         validate!
+        symbolize!
         uniq!
         serialize!
       end

--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -34,7 +34,10 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
       assert_stored campaign, :web, :print, :phone
       campaign.medium << :phone
       assert_stored campaign, :web, :print, :phone
+      campaign.medium << "phone"
+      assert_stored campaign, :web, :print, :phone
       assert_equal 1, campaign.medium.select { |value| value == :phone }.size
+      assert_equal 0, campaign.medium.select { |value| value == "phone" }.size
     end
 
     should "can assign new values at once to bitmask" do


### PR DESCRIPTION
It makes bitmasks easier to use in Rails applications because you don't
have to wonder if you did cast what you got from your web forms.

it keeps hitting me and I end up with things like that :

```
>> c.code
[
    [0] :power,
    [1] :visuprod,
    [2] :no_tva
]
>> c.code << "power"
[
    [0] :power,
    [1] :visuprod,
    [2] :no_tva,
    [3] "power"
]
```

and it kinda confuse my app from time to time :-)
