### PR TITLE
fix values_for

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -65,7 +65,7 @@ module BitmaskAttributes
       def create_attribute_methods_on(model)
         model.class_eval %(
           def self.values_for_#{attribute}      # def self.values_for_numbers
-            #{values}                           #   [:one, :two, :three]
+            #{values.inspect}                   #   [:one, :two, :three]
           end                                   # end
         )
       end


### PR DESCRIPTION
This commit fixes the generated values_for methods. A test for that already existed and failed with

```
 test: Campaign should return all defined values of a given bitmask attribute. ERROR                                                                                        
    undefined local variable or method `webprintemailphone' for #<Class:0x7f89e23cae60>
```

With this commit it passes again.
