### PR TITLE
wrap two scopes in procs to fix migration/startup issues

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -128,7 +128,7 @@ module BitmaskAttributes
               end              
               }                    
           
-          scope :no_#{attribute}, where("#{attribute} = 0 OR #{attribute} IS NULL")
+          scope :no_#{attribute}, proc { where("#{attribute} = 0 OR #{attribute} IS NULL") }
           
           scope :with_any_#{attribute},
             proc { |*values|
@@ -146,7 +146,7 @@ module BitmaskAttributes
         values.each do |value|
           model.class_eval %(
             scope :#{attribute}_for_#{value},
-                  where('#{attribute} & ? <> 0', #{model}.bitmask_for_#{attribute}(:#{value}))
+                  proc { where('#{attribute} & ? <> 0', #{model}.bitmask_for_#{attribute}(:#{value})) }
           )
         end      
       end


### PR DESCRIPTION
Two `class_eval`d bitmask_attributes scopes are not wrapped in procs, which results in migration failures as they attempt to interact with missing tables:

```
/home/aaron/.rvm/gems/ruby-1.9.3-p0@menagerie-pm-3.1/gems/activerecord-3.1.3/lib/active_record/connection_adapters/postgresql_adapter.rb:1021:in `async_exec': PGError: ERROR:  relation "users" does not exist (ActiveRecord::StatementInvalid)
LINE 4:              WHERE a.attrelid = '"users"'::regclass
                                        ^
:             SELECT a.attname, format_type(a.atttypid, a.atttypmod), d.adsrc, a.attnotnull
              FROM pg_attribute a LEFT JOIN pg_attrdef d
                ON a.attrelid = d.adrelid AND a.attnum = d.adnum
             WHERE a.attrelid = '"users"'::regclass
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum
```

The lines in question are:

https://github.com/joelmoss/bitmask_attributes/blob/master/lib/bitmask_attributes/definition.rb#L131
https://github.com/joelmoss/bitmask_attributes/blob/master/lib/bitmask_attributes/definition.rb#L149

This patch wraps those in procs which allows db migrations to run.
Tests still pass.
