### PR TITLE
Prefix the column name with the table name to prevent ambiguous select statements

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -1,7 +1,7 @@
 module BitmaskAttributes
   class Definition
     attr_reader :attribute, :values, :allow_null, :zero_value, :extension
-    
+
     def initialize(attribute, values=[],allow_null = true,zero_value = nil, &extension)
       @attribute = attribute
       @values = values
@@ -9,7 +9,7 @@ module BitmaskAttributes
       @allow_null = allow_null
       @zero_value = zero_value
     end
-    
+
     def install_on(model)
       validate_for model
       generate_bitmasks_on model
@@ -32,7 +32,7 @@ module BitmaskAttributes
           Rails.logger.warn "WARNING: `#{attribute}' is not an attribute of `#{model}'. But, it's ok if it happens during migrations and your \"bitmasked\" attribute is still not created."
         end
       end
-    
+
       def generate_bitmasks_on(model)
         model.bitmasks[attribute] = HashWithIndifferentAccess.new.tap do |mapping|
           values.each_with_index do |value, index|
@@ -40,12 +40,12 @@ module BitmaskAttributes
           end
         end
       end
-    
+
       def override(model)
         override_getter_on(model)
         override_setter_on(model)
       end
-    
+
       def override_getter_on(model)
         model.class_eval %(
           def #{attribute}
@@ -53,7 +53,7 @@ module BitmaskAttributes
           end
         )
       end
-    
+
       def override_setter_on(model)
         model.class_eval %(
           def #{attribute}=(raw_value)
@@ -62,7 +62,7 @@ module BitmaskAttributes
           end
         )
       end
-    
+
       # Returns the defined values as an Array.
       def create_attribute_methods_on(model)
         model.class_eval %(
@@ -71,7 +71,7 @@ module BitmaskAttributes
           end                                   # end
         )
       end
-    
+
       def create_convenience_class_method_on(model)
         model.class_eval %(
           def self.bitmask_for_#{attribute}(*values)
@@ -107,7 +107,7 @@ module BitmaskAttributes
           end
         )
       end
-    
+
       def create_scopes_on(model)
         or_is_null_condition = " OR #{attribute} IS NULL" if allow_null
 


### PR DESCRIPTION
This could use additional work (to quote the table name and column name properly) but this works for now.
