### PR TITLE
Raw bitmask setter

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -64,6 +64,9 @@ module BitmaskAttributes
             unless entry.is_a? Fixnum
               raise ArgumentError, "Expected a Fixnum, but got: \#{entry.inspect}"
             end
+            unless entry.between?(0, 2 ** (self.class.bitmasks[:#{attribute}].size - 1))
+              raise ArgumentError, "Unsupported value for #{attribute}: \#{entry.inspect}"
+            end
             @#{attribute} = nil
             self.send(:write_attribute, :#{attribute}, entry)
           end

--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -86,9 +86,16 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
         assert_unsupported { campaign.medium = [:so_will_this] }
       end
 
-      should "cannot use unsupported values for raw bitmask values" do
+      should "can only use Fixnum values for raw bitmask values" do
         campaign = @campaign_class.new(:medium => :web)
         assert_unsupported { campaign.medium_bitmask = :this_will_fail }
+      end
+
+      should "cannot use unsupported values for raw bitmask values" do
+        campaign = @campaign_class.new(:medium => :web)
+        number_of_attributes = @campaign_class.bitmasks[:medium].size
+        assert_unsupported { campaign.medium_bitmask = (2 ** number_of_attributes) }
+        assert_unsupported { campaign.medium_bitmask = -1 }
       end
 
       should "can determine bitmasks using convenience method" do


### PR DESCRIPTION
In addition to my other pull request I wanted to be able to set a raw Fixnum value as a bitmask. Since I need to reset the instance variable that holds the ValueProxy, I decided to add another convenience method (this time to the instance).

Here is what we had so far:

```
repo = Repository.last
=> #<Repository id: 42, name: "Foo", created_at: "2012-10-02 13:45:35", updated_at: "2012-10-09 08:07:55", architectures: 4>
repo.architectures
=> [:x86_64]
```

Now for the new stuff:

```
repo.architectures_bitmask = 0
=> 0
repo.architectures
=> []
```

```
repo.architectures_bitmask = 4
=> 4
repo.architectures
=> [:x86_64]
```
