### PR TITLE
Introduce inverse convenience class method

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -84,6 +84,17 @@ module BitmaskAttributes
               bitmask | bit
             end
           end
+
+          def self.#{attribute}_for_bitmask(entry)
+            unless entry.is_a? Fixnum
+              raise ArgumentError, "Expected a Fixnum, but got: \#{entry.inspect}"
+            end
+            self.bitmasks[:#{attribute}].inject([]) do |values, (value, bitmask)|
+              values.tap do
+                values << value.to_sym if (entry & bitmask > 0)
+              end
+            end
+          end
         )
       end
 

--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -90,6 +90,15 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
         assert_unsupported { @campaign_class.bitmask_for_medium(:web, :and_this_isnt_valid)  }
       end
 
+      should "can determine bitmask entries using inverse convenience method" do
+        assert @campaign_class.medium_for_bitmask(3)
+        assert_equal([:web, :print], @campaign_class.medium_for_bitmask(3))
+      end
+
+      should "assert use of non Fixnum value in inverse convenience method will result in exception" do
+        assert_unsupported { @campaign_class.medium_for_bitmask(:this_isnt_valid)  }
+      end
+
       should "hash of values is with indifferent access" do
         string_bit = nil
         assert_nothing_raised do


### PR DESCRIPTION
I recently needed to calculate the resulting values from a given Fixnum and I thought having that inverse convenience method around might come in handy for other people, too.

So, where you were always able to do stuff like this:

```
Repository.bitmask_for_architectures :x86_64
=> 4
```

You can now also do this:

```
Repository.architectures_for_bitmask 4
=> [:x86_64]
```

I tried matching the general code style when I added the code and the tests for this inverse convenience class method. Hopefully, you like it.
