### PR TITLE
Zero value

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -180,7 +180,11 @@ module BitmaskAttributes
               if values.blank?
                 no_#{attribute}
               else
-                where("#{attribute} = ?", ::#{model}.bitmask_for_#{attribute}(*values))
+                relation = where("#{attribute} = ?", ::#{model}.bitmask_for_#{attribute}(*values))
+                if values.any?{|value|#{eval_string_for_zero('value')}}
+                  relation = relation.where("#{attribute} = 0#{or_is_null_condition}")
+                end
+                relation
               end
             }
 

--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -272,6 +272,7 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
         assert_equal [campaign], @campaign_class.with_allow_zero(:none)
         assert_equal [], @campaign_class.without_allow_zero(:none)
         assert_equal [campaign], @campaign_class.with_any_allow_zero(:none, :one)
+        assert_equal [campaign], @campaign_class.with_exact_allow_zero(:none)
 
         campaign.allow_zero = :none
         assert campaign.save
@@ -283,6 +284,7 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
         assert_equal [:one],campaign.allow_zero
         assert_equal [], @campaign_class.with_allow_zero(:none)
         assert_equal [campaign], @campaign_class.without_allow_zero(:none)
+        assert_equal [], @campaign_class.with_exact_allow_zero(:none, :one)
       end
 
 


### PR DESCRIPTION
I've added support for querying with the zero value to `without_attr`, `with_any_attr`, `with_exact_attr`, and `attr?`.

Some concerns from @spemmons:

> originally, before the introduction of the :zero_value idea, "some_bitmask?(*values)" was intended to return true if ALL the symbols in the values list are bits set in the bitmask; since :zero_value isn't strictly a "bit" it seems odd to test for it being "set"; if we DO allow it to be passed in the values list, perhaps it should only be allowed as a single value AND the bitmask be set to true... thoughts?

Thanks for your feedback @spemmons!  I agree that it's a bit odd to test for the zero case since there isn't actually a zero bit.  However, it definitely comes in handy and is a nice alternative to `mask.blank?`.  Also, I don't think that any extra testing is required for passing the zero value.  If you pass the zero value with other values you're guaranteed to get `false`, which seems correct to me (i.e. `attribute?(:value, :zero)` always returns `false`).

As for the other methods, it's very handy to have a scope that will handle the zero value correctly, especially since it encompasses `nil` behavior as well.  Let me know what you think!  :)
