### PR TITLE
Scope attribute to table

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -172,7 +172,7 @@ module BitmaskAttributes
               end
             }
 
-          scope :no_#{attribute}, proc { where("#{attribute} = 0#{or_is_null_condition}") }
+          scope :no_#{attribute}, proc { where("#{model.table_name}.#{attribute} = 0#{or_is_null_condition}") }
 
           scope :with_any_#{attribute},
             proc { |*values|


### PR DESCRIPTION
Original PR was #20. #29 was used instead, but it missed one scope. This PR adds the missing scope in the same style as #29.

https://github.com/joelmoss/bitmask_attributes/pull/20
https://github.com/joelmoss/bitmask_attributes/pull/29
