### PR TITLE
Add table scope to or_is_null_condition

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -139,7 +139,7 @@ module BitmaskAttributes
       end
 
       def create_scopes_on(model)
-        or_is_null_condition = " OR #{attribute} IS NULL" if allow_null
+        or_is_null_condition = " OR #{model.table_name}.#{attribute} IS NULL" if allow_null
 
         model.class_eval %(
           scope :with_#{attribute},


### PR DESCRIPTION
This was missing from #29 and #31. It includes the commits from #29.

```
SELECT * FROM "users" WHERE (users.flags & 16 = 0 OR users.flags IS NULL)
```

cc @steveh @adimitrov
