### PR TITLE
do not overwrite saved bitmask value to default - fixes #35

### DIFF
--- a/lib/bitmask_attributes.rb
+++ b/lib/bitmask_attributes.rb
@@ -12,7 +12,7 @@ module BitmaskAttributes
 
       if default = options[:default]
         after_initialize do
-          send("#{attribute}=", default) unless send("#{attribute}?")
+          send("#{attribute}=", default) unless send("#{attribute}?") || persisted?
         end
       end
 

--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BitmaskAttributesTest < ActiveSupport::TestCase
 
-  def self.context_with_classes(label,campaign_class,company_class)
+  def self.context_with_classes(label, campaign_class, company_class)
     context label do
       setup do
         @campaign_class = campaign_class
@@ -304,6 +304,16 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
     assert_equal DefaultValue.new.default_array, [:y, :z]
     assert_equal DefaultValue.new(:default_sym => :x).default_sym, [:x]
     assert_equal DefaultValue.new(:default_array => [:x]).default_array, [:x]
+  end
+  
+  should "save empty bitmask when default defined" do
+    default = DefaultValue.create
+    assert_equal [:y], default.default_sym
+    default.default_sym = []
+    default.save
+    assert_empty default.default_sym
+    default2 = DefaultValue.find(default.id)
+    assert_empty default2.default_sym
   end
 
   context_with_classes 'Campaign with null attributes', CampaignWithNull, CompanyWithNull


### PR DESCRIPTION
Current behavior: if a bitmask has a default defined, you can save an empty bitmask, but you cannot load an object with that empty value. Thus the model does not match the database.

This commit fixes this by not setting the default value if the model is persisted (previously saved).

cc @braddunbar
