### PR TITLE
Don't defer to base class

### DIFF
--- a/lib/bitmask_attributes.rb
+++ b/lib/bitmask_attributes.rb
@@ -26,11 +26,11 @@ module BitmaskAttributes
     end
 
     def bitmask_definitions
-      base_class.base_class_bitmask_definitions
+      base_class_bitmask_definitions
     end
 
     def bitmasks
-      base_class.base_class_bitmasks
+      base_class_bitmasks
     end
 
     protected


### PR DESCRIPTION
This prevents bitmask_attributes from storing the attributes in the base class. Instead, they are stored in the class where they are defined. This allows for subclasses to have different definitions of the bitmask.
