### PR TITLE
create a test that exhibits failing behavior on subclasses

### DIFF
--- a/test/bitmask_attributes_test.rb
+++ b/test/bitmask_attributes_test.rb
@@ -333,4 +333,18 @@ class BitmaskAttributesTest < ActiveSupport::TestCase
   context_with_classes 'Campaign without null attributes', CampaignWithoutNull, CompanyWithoutNull
   context_with_classes 'SubCampaign with null attributes', SubCampaignWithNull, CompanyWithNull
   context_with_classes 'SubCampaign without null attributes', SubCampaignWithoutNull, CompanyWithoutNull
+  
+  should "allow subclasses to have different values for bitmask than parent" do
+    a = CampaignWithNull.new
+    b = SubCampaignWithNull.new
+    a.different_per_class = [:set_for_parent]
+    b.different_per_class = [:set_for_sub]
+    a.save!
+    b.save!
+    a.reload
+    b.reload
+    assert_equal a.different_per_class, [:set_for_parent]
+    assert_equal b.different_per_class, [:set_for_sub]
+  end
+  
 end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -2,6 +2,7 @@ ActiveRecord::Schema.define do
   create_table :campaign_with_nulls do |t|
     t.integer :company_id
     t.integer :medium, :allow_zero, :misc, :Legacy
+    t.integer :different_per_class
     t.string :type # STI
   end
   create_table :company_with_nulls do |t|
@@ -10,6 +11,7 @@ ActiveRecord::Schema.define do
   create_table :campaign_without_nulls do |t|
     t.integer :company_id
     t.integer :medium, :allow_zero, :misc, :Legacy, :null => false, :default => 0
+    t.integer :different_per_class
     t.string :type # STI
   end
   create_table :company_without_nulls do |t|
@@ -30,6 +32,7 @@ class CampaignWithNull < ActiveRecord::Base
   belongs_to :company,:class_name => 'CompanyWithNull'
   bitmask :medium, :as => [:web, :print, :email, :phone]
   bitmask :allow_zero, :as => [:one, :two, :three], :zero_value => :none
+  bitmask :different_per_class, :as => [:set_for_parent]
   bitmask :misc, :as => %w(some useless values) do
     def worked?
       true
@@ -39,6 +42,7 @@ class CampaignWithNull < ActiveRecord::Base
 end
 
 class SubCampaignWithNull < CampaignWithNull
+  bitmask :different_per_class, :as => [:set_for_sub]
 end
 
 class CompanyWithoutNull < ActiveRecord::Base


### PR DESCRIPTION
Because bitmask definitions are stored in the base class, having different definitions in subclasses does not work. On the way in, you can assign values based on the different definitions to instances from different classes. However, on the way back out of the database, depending on the load order, only one definition is honored and values are lost.
