### PR TITLE
Use '>' operator instead of '<>' to make 'with' scopes indexable.

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -152,7 +152,7 @@ module BitmaskAttributes
               else
                 sets = values.map do |value|
                   mask = ::#{model}.bitmask_for_#{attribute}(value)
-                  "#{model.table_name}.#{attribute} & \#{mask} <> 0"
+                  "#{model.table_name}.#{attribute} & \#{mask} > 0"
                 end
                 where(sets.join(' AND '))
               end
@@ -182,14 +182,14 @@ module BitmaskAttributes
               if values.blank?
                 where('#{model.table_name}.#{attribute} > 0')
               else
-                where("#{model.table_name}.#{attribute} & ? <> 0", ::#{model}.bitmask_for_#{attribute}(*values))
+                where("#{model.table_name}.#{attribute} & ? > 0", ::#{model}.bitmask_for_#{attribute}(*values))
               end
             }
         )
         values.each do |value|
           model.class_eval %(
             scope :#{attribute}_for_#{value},
-                  proc { where('#{model.table_name}.#{attribute} & ? <> 0', ::#{model}.bitmask_for_#{attribute}(:#{value})) }
+                  proc { where('#{model.table_name}.#{attribute} & ? > 0', ::#{model}.bitmask_for_#{attribute}(:#{value})) }
           )
         end
       end


### PR DESCRIPTION
**Note:** This requires #57 and #58 for tests to pass. I have excluded those changes from this PR, so tests will continue to fail until those two are merged.

## Why not '<>'?

Database query optimizers typically refuse to use an index for `NOT EQUAL`/`<>`/`!=` conditions. Why? Because it's an easy shortcut. Most of the time, querying for rows where `field <> 'value'` results in an operation where the vast majority of rows are included in the result, so the optimizer won't even bother to calculate the cost of using an index. (I've seen this on postgres, [oracle](https://richardfoote.wordpress.com/2008/08/13/indexes-and-not-equal-not-now-john/), and [ms sql](http://www.mssqltips.com/sqlservertutorial/3203/avoid-using-not-equal-in-where-clause/), and I'd assume it is true for mysql as well)

Unfortunately, the use of `<>` within this gem happens to fall into one of this shortcut's poorly-optimized edge cases. What does this mean?

**The following example requires a database that supports expression indices. I tested this on postgres.**

Say we have a `users` table a `roles` field, and of the 500,000 users we've assigned <1% the role of `:admin` (which is the first role in the array of roles). Starting with this index (which is specifically designed for the `:admin` role):

```SQL
add_index :users, name: 'users_roles_bitmask_1', expression: '(roles & 1)'
# ...
```

And running this line:

```ruby
User.with_roles(:admin)
```

We end up running this query:

```sql
SELECT "users".* FROM "users" WHERE (users.roles & 1 <> 0)
```

Which results in a query plan that sequentially scans the entire table:

```
Seq Scan on users (cost=0.00..9472.07 rows=500000 width=1473)
```

## Using '>' instead

Given the way the `&` operator works, we know that `(users.roles & positive_integer)` will result in a value that is greater than 0 (or NULL). So `(users.roles & positive_integer) > 0` should return exactly the same boolean value as `(users.roles & positive_integer) <> 0`. 

However, the way the query optimizer handles `>` is different. In this case, it will actually calculate the cost of using an index if it thinks it might result in a faster query. Assuming we still have that expression index from above, we can try running this query instead:

```sql
SELECT "users".* FROM "users" WHERE (users.roles & 1 > 0)
```

Which results in a query plan that actually makes use of that index:

```
Bitmap Heap Scan on users  (cost=900.35..10227.04 rows=16667.97 width=1473)
   Recheck Cond: ((roles & 1) > 0)
   ->  Bitmap Index Scan on users_roles_bitmask_1  (cost=0.00..889.77 rows=16667.97 width=0)
```

And, of course, the second query returned the same rows as the first.

## Real-world comparison:

Again, same index as above.

1st time query:

| query | time (ms) |
| ------------- | ------------- |
| SELECT "users".* FROM "users" WHERE (users.roles & 1 <> 0)  | 276.1  |
| SELECT "users".* FROM "users" WHERE (users.roles & 1 > 0)  | 24.9  |

Subsequent queries:

| query  | time (ms) |
| ------------- | ------------- |
| SELECT "users".* FROM "users" WHERE (users.roles & 1 <> 0)  | 101.2  |
| SELECT "users".* FROM "users" WHERE (users.roles & 1 > 0)  | 1.7 |
