### PR TITLE
Expand examples in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,12 @@ to manual bitmasks.
     user.roles << :writer
     user.roles
     # => [:publisher, :editor, :writer]
+    user.save # Commit to the database
+
+You can remove values with `delete`:
+
+    user.roles.delete(:writer)
+    user.save # Remember to save!
 
 It's easy to find out if a record has a given value:
 


### PR DESCRIPTION
Clarifies the fact that you have to call `model.save` after making changes to commit them to the DB. Also adds example of deleting values.

I've done this because we've used this project twice, but have always spent a few minutes trying to remember how to delete values from a bitmask! Adding it to the README will make it nice and obvious.