### PR TITLE
rake db:create throws error in Rails 5

### DIFF
--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -28,7 +28,7 @@ module BitmaskAttributes
         # occurs in the 'test' and 'production' environment or during migration.
         begin
           return if defined?(Rails) && Rails.configuration.cache_classes || !model.table_exists?
-        rescue => e
+        rescue ActiveRecord::NoDatabaseError => e
           return
         end
 

--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -26,15 +26,13 @@ module BitmaskAttributes
         # The model cannot be validated if it is preloaded and the attribute/column is not in the
         # database (the migration has not been run) or table doesn't exist. This usually
         # occurs in the 'test' and 'production' environment or during migration.
-        begin
-          return if defined?(Rails) && Rails.configuration.cache_classes || !model.table_exists?
-        rescue ActiveRecord::NoDatabaseError => e
-          return
-        end
+        return if defined?(Rails) && Rails.configuration.cache_classes || !model.table_exists?
 
         unless model.columns.detect { |col| col.name == attribute.to_s }
           missing_attribute(attribute, model)
         end
+      rescue ActiveRecord::NoDatabaseError
+        nil
       end
 
       def missing_attribute(attribute, model)

--- a/lib/bitmask_attributes/definition.rb
+++ b/lib/bitmask_attributes/definition.rb
@@ -26,7 +26,11 @@ module BitmaskAttributes
         # The model cannot be validated if it is preloaded and the attribute/column is not in the
         # database (the migration has not been run) or table doesn't exist. This usually
         # occurs in the 'test' and 'production' environment or during migration.
-        return if defined?(Rails) && Rails.configuration.cache_classes || !model.table_exists?
+        begin
+          return if defined?(Rails) && Rails.configuration.cache_classes || !model.table_exists?
+        rescue => e
+          return
+        end
 
         unless model.columns.detect { |col| col.name == attribute.to_s }
           missing_attribute(attribute, model)


### PR DESCRIPTION
Expected behavior:

`rake db:create` runs as normal

Actual behavior:

```
rake db:drop
rake aborted!
ActiveRecord::NoDatabaseError: FATAL:  database "foo_development" does not exist
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:688:in `rescue in connect'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:683:in `connect'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:215:in `initialize'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:40:in `new'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:40:in `postgresql_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:809:in `new_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:853:in `checkout_new_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:832:in `try_to_checkout_new_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:793:in `acquire_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:521:in `checkout'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:380:in `connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:1008:in `retrieve_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_handling.rb:118:in `retrieve_connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/connection_handling.rb:90:in `connection'
/usr/local/rvm/gems/ruby-2.4.4/gems/activerecord-5.2.1/lib/active_record/model_schema.rb:324:in `table_exists?'
/usr/local/rvm/gems/ruby-2.4.4/gems/bitmask_attributes-1.0.0/lib/bitmask_attributes/definition.rb:29:in `validate_for'
/usr/local/rvm/gems/ruby-2.4.4/gems/bitmask_attributes-1.0.0/lib/bitmask_attributes/definition.rb:14:in `install_on'
/usr/local/rvm/gems/ruby-2.4.4/gems/bitmask_attributes-1.0.0/lib/bitmask_attributes.rb:25:in `bitmask'
/home/app/webapp/app/models/user.rb:16:in `<class:User>'
/home/app/webapp/app/models/user.rb:4:in `<top (required)>'
......... SNIP .....................
Tasks: TOP => db:drop => db:load_config => environment
(See full trace by running task with --trace)
**Airbrake: closed
```